### PR TITLE
add dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   "dependencies": {
     "@breeffy/react-native-invariant": "^1.0.0",
     "@types/luxon": "^1.25.0",
+    "fast-deep-equal": "^3.1.3",
     "luxon": "^1.25.0",
     "react-native-redash": "^16.0.6",
     "recyclerlistview": "3.0.5-beta.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-native": "*",
     "react-native-gesture-handler": ">=1.9.0",
     "react-native-reanimated": ">=2.0.0",
-    "react-native-svg": "^12.1.0"
+    "react-native-svg": ">=12.1.0"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,7 +4145,7 @@ fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
- Add fast-deep-equal dependency
- Require react-native-svg >= 12.1.0
